### PR TITLE
feat: Add support for Arc browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Download count](https://img.shields.io/github/downloads/chrisgrieser/alfred-chromium-extensions/total?label=Total%20Downloads&style=plastic)
 ![Version number](https://img.shields.io/github/v/release/chrisgrieser/alfred-chromium-extensions?label=Latest%20Release&style=plastic)
 
-Open extension settings or internal pages of Chrome, Brave, or any other
+Open extension settings or internal pages of Chrome, Brave, Arc, or any other
 Chromium-based browser.
 
 <img alt="Showcase" width=70% src="https://github.com/user-attachments/assets/bb4f10fc-f485-4aab-8352-c1af6950a1bc">

--- a/scripts/browser-vars.json
+++ b/scripts/browser-vars.json
@@ -1,11 +1,13 @@
 {
 	"extensionPath": {
 		"Google Chrome": "~/Library/Application Support/Google/Chrome/Default/Extensions",
-		"Brave Browser": "~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Extensions"
+		"Brave Browser": "~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Extensions",
+		"Arc": "~/Library/Application Support/Arc/User Data/Default/Extensions"
 	},
 	"appIcon": {
 		"Google Chrome": "/Applications/Google Chrome.app/Contents/Resources/app.icns",
-		"Brave Browser": "/Applications/Brave Browser.app/Contents/Resources/app.icns"
+		"Brave Browser": "/Applications/Brave Browser.app/Contents/Resources/app.icns",
+		"Arc": "/Applications/Arc.app/Contents/Resources/AppIcon.icns"
 	},
 	"settingsPages": {
 		"Google Chrome": [],
@@ -18,10 +20,12 @@
 			{ "title": "📝 Brave Content", "arg": "brave://settings/braveContent" },
 			{ "title": "🔁 Brave Sync", "arg": "brave://settings/braveSync/setup" },
 			{ "title": "🛠️ Brave Sync Internals", "arg": "brave://sync-internals" }
-		]
+		],
+		"Arc": []
 	},
 	"uri": {
 		"Google Chrome": "chrome://",
-		"Brave Browser": "brave://"
+		"Brave Browser": "brave://",
+		"Arc": "arc://"
 	}
 }


### PR DESCRIPTION
Added support for the Arc browser. Adding "Arc" as a variable in {var:browser} in the Alfred workflow is required.
<img width="408" alt="image" src="https://github.com/user-attachments/assets/e9f77abb-1c49-4428-9816-6359d4678cbf">
